### PR TITLE
adding needs triage auto labeller

### DIFF
--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -1,0 +1,16 @@
+name: 'Mark new issues with needs-triage label'
+
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  label-new-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: initial labelling
+        uses: andymckay/labeler@master
+        with:
+          add-labels: "needs-triage"

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -1,10 +1,6 @@
 name: 'Mark new issues with needs-triage label'
 
-on:
-  issues:
-    types:
-      - reopened
-      - opened
+on: [workflow_call]
 
 jobs:
   label-new-issues:


### PR DESCRIPTION
Adds a workflow which automatically adds `needs-triage` label to new issues