### PR TITLE
Pin actions to a specific hash

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2
+      - uses: ahmadnassri/action-dependabot-auto-merge@5d98f10d910782d0bb431fc03ae26532543ae184  # v2, as of 2021-11-26
         with:
           target: minor
           github-token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: initial labelling
-        uses: andymckay/labeler@master
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
         with:
           add-labels: "needs-triage"

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: initial labelling
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # v1.0.4, as of 2021-11-26
         with:
           add-labels: "needs-triage"

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -7,6 +7,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: initial labelling
-        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # v1.0.4, as of 2021-11-26
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90  # v1.0.4, as of 2021-11-26
         with:
           add-labels: "needs-triage"


### PR DESCRIPTION
This PR pins actions to a specific commit of that action, instead of the development branch.

We should never use an action from its development branch because it can change from run to run. In some cases we can use a release tag (e.g. `v1`), if we trust the owner of the repository (e.g., I expect that GitHub's published actions in the `actions/` org won't be hijacked, or if it is, we'll have bigger problems too). Otherwise, we should pin actions to a specific hash and upgrade if needed.

See [Using third-party actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) for more on this topic.