### PR TITLE
chore:workflows - update idle issue workflow label

### DIFF
--- a/.github/workflows/idle-issues.yml
+++ b/.github/workflows/idle-issues.yml
@@ -11,8 +11,8 @@ jobs:
           days-before-close: -1
           stale-issue-message: ''
           stale-pr-message: ''
-          stale-issue-label: 'idle'
-          stale-pr-label: 'idle'
+          stale-issue-label: '🐌 idle'
+          stale-pr-label: '🐌 idle'
           enable-statistics: true
           ascending: true  # oldest first, for now
           operations-per-run: 300


### PR DESCRIPTION
Update the label from just 'idle' to '🐌 idle' :)

fix #26
