### PR TITLE
Create action for "rebase needed" autolabeler

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       label:
         description: The label to apply when a rebase is needed
-        default: "rebase needed"
+        default: "rebase needed :construction:"
         required: false
         type: string
       comment:

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -1,8 +1,22 @@
 name: "PR Needs Rebase"
+
 on:
-  push:
-  pull_request_target:
-    types: [synchronize]
+  workflow_call:
+    inputs:
+      label:
+        description: The label to apply when a rebase is needed
+        default: "rebase needed"
+        required: false
+        type: string
+      comment:
+        description: The comment to write when a rebase is needed
+        default: "This pull request has merge conflicts that must be resolved before we can merge this."
+        required: false
+        type: string
+    secrets:
+      GH_TOKEN:
+        description: 'Personal access token passed from the caller workflow'
+        required: true
 
 jobs:
   label-rebase-needed:
@@ -11,6 +25,6 @@ jobs:
       - name: Check for merge conflicts
         uses: eps1lon/actions-label-merge-conflict@releases/2.x
         with:
-          dirtyLabel: "rebase needed :construction:"
+          dirtyLabel: ${{ inputs.label }}
           repoToken: "${{ secrets.GH_TOKEN }}"
-          commentOnDirty: "This pull request has merge conflicts that must be resolved before we can merge this."
+          commentOnDirty: ${{ inputs.comment }}

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -12,5 +12,5 @@ jobs:
         uses: eps1lon/actions-label-merge-conflict@releases/2.x
         with:
           dirtyLabel: "rebase needed :construction:"
-          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          repoToken: "${{ secrets.GH_TOKEN }}"
           commentOnDirty: "This pull request has merge conflicts that must be resolved before we can merge this."

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -1,0 +1,16 @@
+name: "PR Needs Rebase"
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  label-rebase-needed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for merge conflicts
+        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        with:
+          dirtyLabel: "rebase needed :construction:"
+          repoToken: "${{ secrets.GITHUB_TOKEN }}"
+          commentOnDirty: "This pull request has merge conflicts that must be resolved before we can merge this."

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Personal access token passed from the caller workflow. Read the documentation on
 
 ## Usage
 
-In the repository that will call this action, you will need to add a `.github/workflows/publish-release.yml` file with the following content:
+In the repository that will call this action, you will need to add a `.github/workflows/pr-rebase-needed.yml` file with the following content:
 
 ### With defaults
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,116 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 ```
 
+## pr-rebase-needed
+
+The `pr-rebase-needed` reusable action is located in `.github/workflows/pr-rebase-needed.yml`.
+
+This reusable action depends on the following actions:
+
+- [actions-label-merge-conflict](https://github.com/marketplace/actions/label-conflicting-pull-requests)
+
+## Inputs
+
+The action has the following inputs:
+
+### label
+
+If your repository uses a label named anything other than `rebase needed` (for example, [BCD](https://github.com/mdn/browser-compat-data) uses `rebase needed 🚧` -- note the emoji), you can set the label here.
+
+- This `input` is optional with a default of `rebase needed`
+
+### comment
+
+When a rebase is needed, the action will write a comment on the pull request to let the PR author know there are merge conflicts.  This can be changed to whatever the repository desires, or left blank if no comment should be added.
+
+- This `input` is optional with a default of `"This pull request has merge conflicts that must be resolved before we can merge this."`
+
+## Secrets
+
+This action requires the following secrets to be passed by the caller. These need to be set as [environmental secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) using the calling repositories settings.
+
+### GH_TOKEN
+
+Personal access token passed from the caller workflow. Read the documentation on [creating a PA token](https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token).
+
+## Usage
+
+In the repository that will call this action, you will need to add a `.github/workflows/publish-release.yml` file with the following content:
+
+### With defaults
+
+```yml
+name: "PR Needs Rebase"
+
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  pr-needs-rebase:
+    uses: mdn/workflows/.github/workflows/pr-needs-rebase.yml@main
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+```
+
+### Overriding some defaults
+
+```yml
+name: "PR Needs Rebase"
+
+on:
+  push:
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  pr-needs-rebase:
+    uses: mdn/workflows/.github/workflows/pr-needs-rebase.yml@main
+    with:
+      label: "rebase needed :construction:"
+    secrets:
+      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+```
+
+### Usage
+
+In the repository that will call this action, you will need to add a `.github/workflows/pr-rebase-needed.yml` file with the following content:
+
+```yml
+name: "PR Needs Rebase"
+on:
+ push:
+ pull_request_target:
+   types: [synchronize]
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        description: The label to apply when a rebase is needed
+        default: "rebase needed"
+        required: false
+        type: string
+      comment:
+        description: The comment to write when a rebase is needed
+        default: "This pull request has merge conflicts that must be resolved before we can merge this."
+        required: false
+        type: string
+    secrets:
+      GH_TOKEN:
+        description: 'Personal access token passed from the caller workflow'
+        required: true
+
+jobs:
+  label-rebase-needed:
+    uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main
+    with:
+      label: "rebase needed :construction:" # Replace with appropriate label
+      comment: "This pull request has merge conflicts."
+
+```
+
 ## publish-release
 
 The `publish-release` GitHub Action automates publication of a new release on GitHub, updates the changelog and also publishes to the NPM registry.

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ The action has the following inputs:
 
 ### label
 
-If your repository uses a label named anything other than `rebase needed` (for example, [BCD](https://github.com/mdn/browser-compat-data) uses `rebase needed 🚧` -- note the emoji), you can set the label here.
+If your repository uses a label named anything other than `rebase needed 🚧` (for example, the repository may use `merge conflicts`), you can set the label here.
 
-- This `input` is optional with a default of `rebase needed`
+- This `input` is optional with a default of `rebase needed :construction:`
 
 ### comment
 

--- a/README.md
+++ b/README.md
@@ -105,44 +105,6 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 ```
 
-### Usage
-
-In the repository that will call this action, you will need to add a `.github/workflows/pr-rebase-needed.yml` file with the following content:
-
-```yml
-name: "PR Needs Rebase"
-on:
- push:
- pull_request_target:
-   types: [synchronize]
-
-on:
-  workflow_call:
-    inputs:
-      label:
-        description: The label to apply when a rebase is needed
-        default: "rebase needed"
-        required: false
-        type: string
-      comment:
-        description: The comment to write when a rebase is needed
-        default: "This pull request has merge conflicts that must be resolved before we can merge this."
-        required: false
-        type: string
-    secrets:
-      GH_TOKEN:
-        description: 'Personal access token passed from the caller workflow'
-        required: true
-
-jobs:
-  label-rebase-needed:
-    uses: mdn/workflows/.github/workflows/pr-rebase-needed.yml@main
-    with:
-      label: "rebase needed :construction:" # Replace with appropriate label
-      comment: "This pull request has merge conflicts."
-
-```
-
 ## publish-release
 
 The `publish-release` GitHub Action automates publication of a new release on GitHub, updates the changelog and also publishes to the NPM registry.


### PR DESCRIPTION
Created at the request of @schalkneethling (see https://github.com/mdn/browser-compat-data/pull/15931#issuecomment-1111316493).  This PR adds a GitHub Actions workflow to automatically (un)label pull requests that have merge conflicts.