### PR TITLE
Allow for passing in arguments to `npm publish` in publish-release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,6 +18,11 @@ on:
         default: true
         required: false
         type: boolean
+      npm-publish-args:
+        description: Arguments passed to `npm publish` command; ignored if "npm-publish" is false
+        default: ""
+        required: false
+        type: string
       registry-url:
         description: The registry to publish to
         default: "https://registry.npmjs.org"
@@ -54,7 +59,7 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
       - run: yarn install --frozen-lockfile
         if: ${{ steps.release.outputs.release_created }}
-      - run: npm publish
+      - run: npm publish ${{ inputs.npm-publish-args }}
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_AUTH_TOKEN}}
         if: ${{ steps.release.outputs.release_created }}

--- a/README.md
+++ b/README.md
@@ -137,6 +137,13 @@ The version of Node.js to use for the release. This action supports all [active 
 Whether to publish the package to the NPM registry.
 
 - This `input` is optional with a default of `true`
+
+### npm-publish-args
+
+Arguments to pass to the `npm publish` command.  This is ignored if `npm-publish` is set to `false`.
+
+- This `input` is optional with a default of an empty string
+
 ### registry-url
 
 The registry to publish to.


### PR DESCRIPTION
This PR allows passing in custom arguments to the `npm publish` command in the `publish-release` workflows.  This will allow us to hook in BCD, since BCD is designed to build bundled releases (see https://github.com/mdn/browser-compat-data/blob/03ab803b34ba650c1acb91949191ae0d816c5a0a/.github/workflows/release.yml#L24).