### PR TITLE
Add the lock-closed workflow

### DIFF
--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -1,0 +1,18 @@
+name: 'Lock old issues and pull requests'
+on:
+  schedule:
+    - cron: '0 * * * *'
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/lock-threads@v3

--- a/README.md
+++ b/README.md
@@ -189,6 +189,19 @@ jobs:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 ```
 
+## lock-closed
+
+The `lock-closed` GitHub Action automatically locks issues and PRs that have been closed for more than a year.
+It is intended to reduce "necrobumping" (the addition of comments, including spam, to old/closed issues).
+
+This reusable action depends on the following actions:
+
+- [dessant/lock-threads@v3](https://github.com/dessant/lock-threads)
+
+> **Note:** The workflow is a copy of the default example: https://github.com/dessant/lock-threads#examplesis.
+> Usage, inputs, outputs, and amples are well documented in https://github.com/dessant/lock-threads
+
+
 ## publish-release
 
 The `publish-release` GitHub Action automates publication of a new release on GitHub, updates the changelog and also publishes to the NPM registry.


### PR DESCRIPTION
This adds the lock-closed workflow, which automatically locks closed issues and PRs after a year. This was originally posted in https://github.com/mdn/content/pull/14678.

@schalkneethling I don't know how this repo works. Is it automatically run for all other repos, or is this just a common repo, and the workflow have to be copied across (I'm really asking if https://github.com/mdn/content/pull/14678 should be closed because this is the only copy we need).