### PR TITLE
fix: make npm token optional for publish release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -37,7 +37,7 @@ name: publish-release
         required: true
       NPM_AUTH_TOKEN:
         description: Your NPM registry token
-        required: true
+        required: false
 jobs:
   release-please:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ Personal access token passed from the caller workflow. Read the documentation on
 
 Authentication token for the NPM registry. Read the documentation for details on [creating a token](https://docs.npmjs.com/creating-and-viewing-access-tokens).
 
+> NOTE: When skipping NPM publishing, this token is not required.
+
 ## Usage
 
 In the repository that will call this action, you will need to add a `.github/workflows/publish-release.yml` file with the following content:


### PR DESCRIPTION
Make the npm auth token optional for the publish release workflow.

fix #42
