### PR TITLE
feat: run workflow only on target repo

### DIFF
--- a/.github/workflows/auto-merge-workflows.yml
+++ b/.github/workflows/auto-merge-workflows.yml
@@ -3,6 +3,8 @@ on: [pull_request_target]
 
 jobs:
   auto-merge:
-    uses:  mdn/workflows/.github/workflows/auto-merge.yml@main
+    uses: mdn/workflows/.github/workflows/auto-merge.yml@main
+    with:
+      target-repo: "mdn/workflows"
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,18 +1,24 @@
 name: auto-merge
 
-on: 
+on:
   workflow_call:
+    inputs:
+      target-repo:
+        description: The repo to run this action on. This is to prevent actions from running on forks unless intended.
+        required: true
+        type: string
     secrets:
       GH_TOKEN:
-        description: 'Personal access token passed from the caller workflow'
+        description: "Personal access token passed from the caller workflow"
         required: true
 
 jobs:
   auto-merge:
+    if: github.repository == ${{ inputs.target-repo }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: ahmadnassri/action-dependabot-auto-merge@5d98f10d910782d0bb431fc03ae26532543ae184  # v2, as of 2021-11-26
+      - uses: ahmadnassri/action-dependabot-auto-merge@5d98f10d910782d0bb431fc03ae26532543ae184 # v2, as of 2021-11-26
         with:
           target: minor
           github-token: ${{ secrets.GH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,16 @@ This reusable action depends on the following actions:
 - [checkout](https://github.com/marketplace/actions/checkout)
 - [dependabot-auto-merge](https://github.com/marketplace/actions/dependabot-auto-merge)
 
+## Inputs
+
+The action has the following inputs:
+
+### target-repo
+
+Specify the target repository this action should run on. This is used to prevent actions from running on repositories other than the target repository. For example, specifying a `target-repo` of `mdn/workflows` will prevent the action from running on `fork/workflows`.
+
+- This `input` is required
+
 ### Usage
 
 In the repository that will call this action, you will need to add a `.github/workflows/auto-merge.yml` file with the following content:
@@ -28,7 +38,9 @@ on: [pull_request_target]
 
 jobs:
   auto-merge:
-    uses:  mdn/workflows/.github/workflows/auto-merge.yml@main
+    uses: mdn/workflows/.github/workflows/auto-merge.yml@main
+    with:
+      target-repo: "mdn/workflows"
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
 ```
@@ -53,7 +65,7 @@ If your repository uses a label named anything other than `rebase needed 🚧` (
 
 ### comment
 
-When a rebase is needed, the action will write a comment on the pull request to let the PR author know there are merge conflicts.  This can be changed to whatever the repository desires, or left blank if no comment should be added.
+When a rebase is needed, the action will write a comment on the pull request to let the PR author know there are merge conflicts. This can be changed to whatever the repository desires, or left blank if no comment should be added.
 
 - This `input` is optional with a default of `"This pull request has merge conflicts that must be resolved before we can merge this."`
 
@@ -125,7 +137,7 @@ If your repository uses a label named anything other than `🐌 idle` (for examp
 
 ### comment
 
-When the issue or pull request becomes stale, the action will write a comment on the pull request to let the author know.  This can be changed to whatever the repository desires, or left blank if no comment should be added.  If `closure-days` is set, this is highly recommended to ensure the author knows their issue or PR will be closed.
+When the issue or pull request becomes stale, the action will write a comment on the pull request to let the author know. This can be changed to whatever the repository desires, or left blank if no comment should be added. If `closure-days` is set, this is highly recommended to ensure the author knows their issue or PR will be closed.
 
 - This `input` is optional with a default of an empty string
 
@@ -137,7 +149,7 @@ The number of days before the issue or pull request is considered idle and the l
 
 ### closure-days
 
-The number of days before the idle issue or pull request is closed.  Set to -1 to disable.
+The number of days before the idle issue or pull request is closed. Set to -1 to disable.
 
 - This `input` is optional with a default of -1
 
@@ -201,7 +213,6 @@ This reusable action depends on the following actions:
 > **Note:** The workflow is a copy of the default example: https://github.com/dessant/lock-threads#examplesis.
 > Usage, inputs, outputs, and amples are well documented in https://github.com/dessant/lock-threads
 
-
 ## publish-release
 
 The `publish-release` GitHub Action automates publication of a new release on GitHub, updates the changelog and also publishes to the NPM registry.
@@ -217,6 +228,7 @@ This reusable action depends on the following actions:
 ## Inputs
 
 The action has the following inputs:
+
 ### release-type
 
 This is can be one of the release types as [detailed in the release please docs](https://github.com/googleapis/release-please#release-types-supported).
@@ -237,7 +249,7 @@ Whether to publish the package to the NPM registry.
 
 ### npm-publish-args
 
-Arguments to pass to the `npm publish` command.  This is ignored if `npm-publish` is set to `false`.
+Arguments to pass to the `npm publish` command. This is ignored if `npm-publish` is set to `false`.
 
 - This `input` is optional with a default of an empty string
 
@@ -277,7 +289,7 @@ on:
 
 jobs:
   publish-release:
-    uses:  mdn/workflows/.github/workflows/publish-release.yml@main
+    uses: mdn/workflows/.github/workflows/publish-release.yml@main
     secrets:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}
       NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
@@ -295,7 +307,7 @@ on:
 
 jobs:
   publish-release:
-    uses:  mdn/workflows/.github/workflows/publish-release.yml@main
+    uses: mdn/workflows/.github/workflows/publish-release.yml@main
     with:
       release-type: python
     secrets:
@@ -315,7 +327,7 @@ on:
 
 jobs:
   publish-release:
-    uses:  mdn/workflows/.github/workflows/publish-release.yml@main
+    uses: mdn/workflows/.github/workflows/publish-release.yml@main
     with:
       npm-publish: false
     secrets:


### PR DESCRIPTION
Only run the `auto-merge` action on the target repository.

Part of #53
