### PR TITLE
fix: idle workflow should not close

### DIFF
--- a/.github/workflows/idle.yml
+++ b/.github/workflows/idle.yml
@@ -7,6 +7,11 @@ on:
         description: The repo to run this action on. This is to prevent actions from running on forks unless intended.
         required: true
         type: string
+      days-before-close:
+        description: The idle number of days before closing the stale issues or the stale pull requests.
+        default: -1
+        required: false
+        type: number
       label:
         description: The label to apply when the issue/PR is idle
         default: "🐌 idle"
@@ -26,6 +31,7 @@ jobs:
       - uses: actions/stale@v5
         with:
           days-before-stale: ${{ inputs.stale-days }}
+          days-before-close: ${{ inputs.days-before-close }}
           stale-issue-label: ${{ inputs.label }}
           stale-pr-label: ${{ inputs.label }}
           enable-statistics: true


### PR DESCRIPTION
I am guessing that as part of a merge conflict we lost the setting that told the `idle` workflow to not close issues and pull requests.

This fixes this ommision.