### PR TITLE
feat: sync Markdownlint jobs from mdn/content

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -34,4 +34,5 @@ jobs:
 
       - name: Lint Markdown files
         run: |
+          echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
           npx markdownlint-cli '*.md' -i LICENSE.md -i CODE_OF_CONDUCT.md

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,5 +1,18 @@
 name: markdown-lint
 
+# Used to run Markdownlint across all files in the repo.
+# Useful for PRs that touch the installed dependcies or Markdownlint configuration files
+# Sample trigger filter:
+# on:
+#   pull_request:
+#     branches:
+#       - main
+#     paths:
+#       - .markdownlint-cli2.jsonc
+#       - package.json
+#       - yarn.lock
+#       - .github/workflows/markdown-lint.yml
+
 on:
   workflow_call:
     inputs:
@@ -17,6 +30,16 @@ on:
         default: "yarn"
         required: false
         type: string
+      install-command:
+        description: The command to install the package dependencies.
+        default: "yarn --frozen-lockfile"
+        required: false
+        type: string
+      lint-command:
+        description: Which commmand or script used to invoke Markdown linting
+        default: "yarn lint:md"
+        required: false
+        type: string
 
 jobs:
   markdown-lint:
@@ -32,7 +55,10 @@ jobs:
           node-version: ${{ inputs.node-version }}
           cache: ${{ inputs.cache }}
 
+      - name: Install packages
+        run: ${{ inputs.install-command }}
+
       - name: Lint Markdown files
         run: |
           echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
-          npx markdownlint-cli '*.md' -i LICENSE.md -i CODE_OF_CONDUCT.md
+          ${{ inputs.lint-command }}

--- a/.github/workflows/markdownlint-problem-matcher.json
+++ b/.github/workflows/markdownlint-problem-matcher.json
@@ -1,0 +1,18 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "markdownlint",
+      "severity": "warning",
+      "pattern": [
+        {
+          "regexp": "^([^:]*):(\\d+):?(\\d+)?\\s([\\w-\\/]*)\\s(.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "code": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/pr-check-markdownlint.yml
+++ b/.github/workflows/pr-check-markdownlint.yml
@@ -1,0 +1,74 @@
+name: Markdownlint (PR files)
+
+# Used to run linting only on the files changed in a PR.
+# This is useful in conjunction with the other global Markdownlint job,
+# which will test larger configuration changes across a repository.
+# A sample filter to only run the job when a PR touches a Markdown file
+# on:
+#   pull_request:
+#     branches:
+#       - main
+#     paths:
+#       - "**/*.md"
+
+on:
+   workflow_call:
+    inputs:
+      target-repo:
+        description: The repo to run this action on. This is to prevent actions from running on forks unless intended.
+        required: true
+        type: string
+      node-version:
+        description: The node version to setup and use.
+        default: 16
+        required: false
+        type: number
+      cache:
+        description: Which package manager cache to use
+        default: "yarn"
+        required: false
+        type: string
+      install-command:
+        description: The command to install the package dependencies.
+        default: "yarn --frozen-lockfile"
+        required: false
+        type: string
+      changed-filter:
+        description: File filter glob to limit which changed files to lint
+        default: "**/*.md"
+        required: false
+        type: string
+      lint-command:
+        description: Which commmand or script used to invoke Markdown linting
+        default: "yarn markdownlint-cli2 ${files_to_lint}"
+        required: false
+        type: string
+
+jobs:
+  markdown-lint:
+    if: github.repository == ${{ inputs.target-repo }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v29.0.9
+        with:
+          files: ${{ inputs.changed-filter }}
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.cache }}
+
+      - name: Install packages
+        run: ${{ inputs.install-command }}
+
+      - name: Lint Markdown files
+        run: |
+          echo "::add-matcher::.github/workflows/markdownlint-problem-matcher.json"
+          files_to_lint="${{ steps.changed-files.outputs.all_changed_files }}"
+          ${{ inputs.lint-command }}


### PR DESCRIPTION
Allows for annotations on the file tab of PRs for any of the issues. Left the hardcoding "warning" severity used by mdn/content instead of the default Error