### PR TITLE
feat: change JSON lint to use Prettier

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -35,5 +35,4 @@ jobs:
 
       - name: Lint JSON files
         run: |
-          npm install --no-save eslint eslint-plugin-json
-          npx eslint . --ext .json
+          npx prettier -c "**/*.json"


### PR DESCRIPTION
mdn/content switched over awhile ago, since Prettier is more commonly used for formatting in the repos for non-JS files