### PR TITLE
chore: update idle workflow

### DIFF
--- a/.github/workflows/idle.yml
+++ b/.github/workflows/idle.yml
@@ -14,12 +14,12 @@ on:
         type: number
       label:
         description: The label to apply when the issue/PR is idle
-        default: "🐌 idle"
+        default: "idle"
         required: false
         type: string
       stale-days:
         description: How many days before the issue/PR is considered idle
-        default: 37
+        default: 30
         required: false
         type: number
 


### PR DESCRIPTION
Update the idle workflow label and default for `stale-days`