### PR TITLE
feat(publish-release): migrate from yarn to npm

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,9 +15,14 @@ name: publish-release
         type: string
       node-version:
         description: The Nodejs version to use
-        default: 12
+        default: 16
         required: false
         type: number
+      package-manager:
+        description: The package manager used by the package (npm or yarn)
+        default: npm
+        required: false
+        type: string
       npm-publish:
         description: Whether to publish the package to npm
         default: true
@@ -61,7 +66,9 @@ jobs:
           registry-url: '${{ inputs.registry-url }}'
         if: inputs.npm-publish && steps.release.outputs.release_created
       - run: yarn install --frozen-lockfile
-        if: inputs.npm-publish && steps.release.outputs.release_created
+        if: inputs.npm-publish && steps.release.outputs.release_created && inputs.package-manager == 'yarn'
+      - run: npm ci
+        if: inputs.npm-publish && steps.release.outputs.release_created && inputs.package-manager == 'npm'
       - run: 'npm publish ${{ inputs.npm-publish-args }}'
         env:
           NODE_AUTH_TOKEN: '${{secrets.NPM_AUTH_TOKEN}}'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ name: publish-release
         type: string
       node-version:
         description: The Nodejs version to use
-        default: 16
+        default: 12
         required: false
         type: number
       npm-publish:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -61,6 +61,7 @@ jobs:
           registry-url: '${{ inputs.registry-url }}'
         if: inputs.npm-publish && steps.release.outputs.release_created
       - run: npm ci
+        if: inputs.npm-publish && steps.release.outputs.release_created
       - run: 'npm publish ${{ inputs.npm-publish-args }}'
         env:
           NODE_AUTH_TOKEN: '${{secrets.NPM_AUTH_TOKEN}}'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,11 +18,6 @@ name: publish-release
         default: 16
         required: false
         type: number
-      package-manager:
-        description: The package manager used by the package (npm or yarn)
-        default: npm
-        required: false
-        type: string
       npm-publish:
         description: Whether to publish the package to npm
         default: true
@@ -65,10 +60,7 @@ jobs:
           node-version: '${{ inputs.node-version }}'
           registry-url: '${{ inputs.registry-url }}'
         if: inputs.npm-publish && steps.release.outputs.release_created
-      - run: yarn install --frozen-lockfile
-        if: inputs.npm-publish && steps.release.outputs.release_created && inputs.package-manager == 'yarn'
       - run: npm ci
-        if: inputs.npm-publish && steps.release.outputs.release_created && inputs.package-manager == 'npm'
       - run: 'npm publish ${{ inputs.npm-publish-args }}'
         env:
           NODE_AUTH_TOKEN: '${{secrets.NPM_AUTH_TOKEN}}'


### PR DESCRIPTION
### Description

Migrates from yarn to npm.

### Motivation

This currently blocks the release of `@mdn/bob` v3.0.0, which has migrated to npm.

### Additional details

I checked and we don't use this workflow in a lot of repos (I have a folder where I have **all** mdn/* repos checked out):

<img width="502" alt="image" src="https://user-images.githubusercontent.com/495429/218045972-f3e57108-eed1-41bb-849f-e7eb3d9ed549.png">

- `interactive-examples` has an [open PR to migrate to npm](https://github.com/mdn/interactive-examples/pull/2388)
- `data` had never been migrated to yarn in the first place (so it seems)
- `markdown` will be archived anytime soon and won't have further releases
- `bob` has already been migrated to npm
- `mdn-minimalist` has already been archived

### Related issues and pull requests

See the workflow runs on [this commit](https://github.com/mdn/bob/commit/8df94dd1a08125ce83a55233429726500cfc779f).
