### PR TITLE
publish-release: add "cache" input

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -66,6 +66,10 @@ jobs:
           registry-url: '${{ inputs.registry-url }}'
           cache: ${{ inputs.cache }}
         if: inputs.npm-publish && steps.release.outputs.release_created
+      - run: yarn install --frozen-lockfile
+        if: inputs.cache === 'yarn' && inputs.npm-publish && steps.release.outputs.release_created
+      - run: npm ci
+        if: inputs.cache === 'npm' && inputs.npm-publish && steps.release.outputs.release_created
       - run: 'npm publish ${{ inputs.npm-publish-args }}'
         env:
           NODE_AUTH_TOKEN: '${{secrets.NPM_AUTH_TOKEN}}'

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -2,6 +2,11 @@ name: publish-release
 'on':
   workflow_call:
     inputs:
+      cache:
+        description: Which package manager cache to use
+        default: "yarn"
+        required: false
+        type: string
       target-repo:
         description: The repo to run this action on. This is to prevent actions from running on forks unless intended.
         required: true
@@ -59,8 +64,7 @@ jobs:
         with:
           node-version: '${{ inputs.node-version }}'
           registry-url: '${{ inputs.registry-url }}'
-        if: inputs.npm-publish && steps.release.outputs.release_created
-      - run: yarn install --frozen-lockfile
+          cache: ${{ inputs.cache }}
         if: inputs.npm-publish && steps.release.outputs.release_created
       - run: 'npm publish ${{ inputs.npm-publish-args }}'
         env:


### PR DESCRIPTION
This PR updates the `publish-release` workflow by adding a `cache` argument to allow switching between NPM and Yarn as the package manager.