### PR TITLE
chore!: bump default NodeJS version to 18

### DIFF
--- a/.github/workflows/json-lint.yml
+++ b/.github/workflows/json-lint.yml
@@ -1,7 +1,7 @@
 name: json-lint
 
 on:
-   workflow_call:
+  workflow_call:
     inputs:
       target-repo:
         description: The repo to run this action on. This is to prevent actions from running on forks unless intended.
@@ -9,7 +9,7 @@ on:
         type: string
       node-version:
         description: The node version to setup and use.
-        default: 16
+        default: 18
         required: false
         type: number
       cache:
@@ -17,7 +17,6 @@ on:
         default: "yarn"
         required: false
         type: string
-
 
 jobs:
   json-lint:

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -1,7 +1,7 @@
 name: markdown-lint
 
 on:
-   workflow_call:
+  workflow_call:
     inputs:
       target-repo:
         description: The repo to run this action on. This is to prevent actions from running on forks unless intended.
@@ -9,7 +9,7 @@ on:
         type: string
       node-version:
         description: The node version to setup and use.
-        default: 16
+        default: 18
         required: false
         type: number
       cache:
@@ -17,7 +17,6 @@ on:
         default: "yarn"
         required: false
         type: string
-
 
 jobs:
   markdown-lint:

--- a/.github/workflows/pr-check-redirects.yml
+++ b/.github/workflows/pr-check-redirects.yml
@@ -1,7 +1,7 @@
 name: Check Redirects
 
 on:
-   workflow_call:
+  workflow_call:
     inputs:
       target-repo:
         description: The repo to run this action on. This is to prevent actions from running on forks unless intended.
@@ -14,7 +14,7 @@ on:
         type: string
       node-version:
         description: The node version to setup and use.
-        default: 16
+        default: 18
         required: false
         type: number
       target-locale:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,5 +1,5 @@
 name: publish-release
-'on':
+"on":
   workflow_call:
     inputs:
       target-repo:
@@ -15,7 +15,7 @@ name: publish-release
         type: string
       node-version:
         description: The Nodejs version to use
-        default: 12
+        default: 18
         required: false
         type: number
       npm-publish:
@@ -27,12 +27,12 @@ name: publish-release
         description: >-
           Arguments passed to `npm publish` command; ignored if "npm-publish" is
           false
-        default: ''
+        default: ""
         required: false
         type: string
       registry-url:
         description: The registry to publish to
-        default: 'https://registry.npmjs.org'
+        default: "https://registry.npmjs.org"
         required: false
         type: string
     secrets:
@@ -50,19 +50,19 @@ jobs:
       - uses: GoogleCloudPlatform/release-please-action@v3.7.3
         id: release
         with:
-          token: '${{ secrets.GH_TOKEN }}'
-          release-type: '${{ inputs.release-type }}'
+          token: "${{ secrets.GH_TOKEN }}"
+          release-type: "${{ inputs.release-type }}"
           package-name: release-please-action
       - uses: actions/checkout@v3
         if: inputs.npm-publish && steps.release.outputs.release_created
       - uses: actions/setup-node@v3
         with:
-          node-version: '${{ inputs.node-version }}'
-          registry-url: '${{ inputs.registry-url }}'
+          node-version: "${{ inputs.node-version }}"
+          registry-url: "${{ inputs.registry-url }}"
         if: inputs.npm-publish && steps.release.outputs.release_created
       - run: yarn install --frozen-lockfile
         if: inputs.npm-publish && steps.release.outputs.release_created
-      - run: 'npm publish ${{ inputs.npm-publish-args }}'
+      - run: "npm publish ${{ inputs.npm-publish-args }}"
         env:
-          NODE_AUTH_TOKEN: '${{secrets.NPM_AUTH_TOKEN}}'
+          NODE_AUTH_TOKEN: "${{secrets.NPM_AUTH_TOKEN}}"
         if: inputs.npm-publish && steps.release.outputs.release_created


### PR DESCRIPTION
This PR bumps the default NodeJS version within workflows to "18", following an MDN-wide upgrade.
