### PR TITLE
"needs-triage" label should be "needs triage"

### DIFF
--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -9,7 +9,7 @@ on:
         type: string
       add-labels:
         description: Labels to add as a comma separated list.
-        default: "needs-triage"
+        default: "needs triage"
         required: false
         type: string
 


### PR DESCRIPTION
The convention for labels is:

* all lowercase
* spaces instead of underscores or hyphens

We have both in some repos (Yari) and it would be good to consolidate these