### PR TITLE
chore(workflow): Remove comment action from merge conflict labeler

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -12,11 +12,6 @@ on:
         default: "merge conflicts :construction:"
         required: false
         type: string
-      comment:
-        description: The comment to write when a rebase is needed
-        default: "This pull request has merge conflicts that must be resolved before it can be merged."
-        required: false
-        type: string
     secrets:
       GH_TOKEN:
         description: "Personal access token passed from the caller workflow"
@@ -32,4 +27,3 @@ jobs:
         with:
           dirtyLabel: ${{ inputs.label }}
           repoToken: "${{ secrets.GH_TOKEN }}"
-          commentOnDirty: ${{ inputs.comment }}


### PR DESCRIPTION
We may want to disable comments on merge conflicts entirely. Opening a draft PR for early feedback.

### Motivation

Some reviewers find that pull requests with many comments are an indicator of activity. If there are only bot comments, this may discourage people from reviewing changes as it appears a discussion is ongoing via PR comments.

__related issues and pull requests:__

- [ ] https://github.com/mdn/workflows/issues/120