### PR TITLE
build(deps): bump eps1lon/actions-label-merge-conflict from releases/2.x to v3

### DIFF
--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for merge conflicts
-        uses: eps1lon/actions-label-merge-conflict@releases/2.x
+        uses: eps1lon/actions-label-merge-conflict@v3
         with:
           dirtyLabel: ${{ inputs.label }}
           repoToken: "${{ secrets.GH_TOKEN }}"


### PR DESCRIPTION
### Description

The old version of `eps1lon/actions-label-merge-conflict` did not use the standard semantic version, so the [dependabot](https://github.com/apps/dependabot) could not handle the bump of the dependency. So make a manual upgrade for it.

> The new version of `eps1lon/actions-label-merge-conflict` uses the standard semantic version. Which means the dependabot can now resolve the upgrades of it in the future :)

The [change log of the new version](https://github.com/eps1lon/actions-label-merge-conflict/blob/main/CHANGELOG.md#300):

> - Update to node20 (eps1lon/actions-label-merge-conflict#115)
