### PR TITLE
fix(ci): check on dependabot user instead of actor

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -29,7 +29,7 @@ on:
 
 jobs:
   auto-merge:
-    if: github.repository == inputs.target-repo && github.actor == 'dependabot[bot]'
+    if: github.repository == inputs.target-repo && github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing to MDN Web Docs. Adding details below will help us to merge your PR faster. -->

### Description

Modify the automerge to check on dependabot user instead of actor to prevent force pushes from forks

### Motivation

<!-- ❓ Why are you making these changes and how do they help readers? -->
Make sure automerging only works for dependabot

### Additional details

Bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1914746
