### PR TITLE
chore(deps): bump node from v18 to v20

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -9,7 +9,7 @@ on:
         type: string
       node-version:
         description: The node version to setup and use.
-        default: 18
+        default: 20
         required: false
         type: number
       cache:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ name: publish-release
         type: string
       node-version:
         description: The Nodejs version to use
-        default: 18
+        default: 20
         required: false
         type: number
       npm-publish:

--- a/docs/markdown-lint.md
+++ b/docs/markdown-lint.md
@@ -27,7 +27,7 @@ Specify the target repository this action should run on. This is used to prevent
 
 The node version to setup and use.
 
-- This `input` is optional, with a default of 16.
+- This `input` is optional, with a default of `20`.
 
 #### cache
 
@@ -77,6 +77,6 @@ jobs:
     uses: mdn/workflows/.github/workflows/markdown-lint.yml@main
     with:
       cache: "npm"
-      node-version: 18
+      node-version: 20
       target-repo: "mdn/workflows"
 ```

--- a/docs/publish-release.md
+++ b/docs/publish-release.md
@@ -36,7 +36,7 @@ This is can be one of the release types as [detailed in the release please docs]
 
 The version of Node.js to use for the release. This action supports all [active and maintenance releases](https://nodejs.org/en/about/releases/) of Node.js.
 
-- This `input` is optional with a default of `12`
+- This `input` is optional with a default of `20`
 
 #### npm-publish
 


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Bumps Node.js from v18 to v20.

### Motivation

Node.js v18 will no longer be maintained after April 2025.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Part of https://github.com/mdn/mdn/issues/521.
