### PR TITLE
ci(workflows): pin 3rd party actions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: ahmadnassri/action-dependabot-auto-merge@v2.6
+      - uses: ahmadnassri/action-dependabot-auto-merge@45fc124d949b19b6b8bf6645b6c9d55f4f9ac61a # v2.6.6
         with:
           approve: ${{ inputs.auto-approve }}
           command: ${{ inputs.command }}

--- a/.github/workflows/lock-closed.yml
+++ b/.github/workflows/lock-closed.yml
@@ -24,6 +24,6 @@ jobs:
     if: github.repository == inputs.target-repo
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v5
+      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
         with:
           issue-inactive-days: ${{ inputs.issue-inactive-days }}

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -19,6 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: initial labelling
-        uses: andymckay/labeler@1.0.4
+        uses: andymckay/labeler@e6c4322d0397f3240f0e7e30a33b5c5df2d39e90 # v1.0.4
         with:
           add-labels: ${{ inputs.add-labels }}

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check for merge conflicts
-        uses: eps1lon/actions-label-merge-conflict@v3
+        uses: eps1lon/actions-label-merge-conflict@1df065ebe6e3310545d4f4c4e862e43bdca146f0 # v3.0.3
         with:
           dirtyLabel: ${{ inputs.label }}
           repoToken: "${{ secrets.GH_TOKEN }}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -47,7 +47,7 @@ jobs:
     if: github.repository == inputs.target-repo
     runs-on: ubuntu-latest
     steps:
-      - uses: GoogleCloudPlatform/release-please-action@v4.1.3
+      - uses: GoogleCloudPlatform/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         id: release
         with:
           token: "${{ secrets.GH_TOKEN }}"

--- a/.github/workflows/set-default-labels.yml
+++ b/.github/workflows/set-default-labels.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: lannonbr/issue-label-manager-action@4.0.0
+      - uses: lannonbr/issue-label-manager-action@e8dbcd8198e86a1e98d5372e55db976fed9ba6f7 # v4.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Pin 3rd party actions to a commit hash to mitigate the risk of a supply chain attack.

### Motivation

Resolves [7 CodeQL code scanning alerts](https://github.com/mdn/workflows/security/code-scanning?query=is%3Aopen+branch%3Amain+rule%3Aactions%2Funpinned-tag).

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related:

- https://github.com/mdn/browser-compat-data/pull/25793
- https://github.com/mdn/content/pull/38016
- https://github.com/mdn/translated-content/pull/25752
- https://github.com/mdn/translated-content-de/pull/53
