### PR TITLE
docs(README): remove allo-allo workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Reusable GitHub Actions workflows for use in MDN repositories.
 
 ## Available actions
 
-- [allo-allo](.github/workflows/allo-allo.yml) ([docs](docs/allo-allo.md)) - a welcome bot for new contributors
 - [auto-merge](.github/workflows/auto-merge.yml) ([docs](docs/auto-merge.md)) - automatically merge pull requests
 - [idle](.github/workflows/idle.yml) ([docs](docs/idle.md)) - mark issues and pull requests as idle
 - [lock-closed](.github/workflows/lock-closed.yml) ([docs](docs/lock-closed.md)) - lock closed issues and pull requests


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Removes the `allo-allo` workflow from the README.

### Motivation

The workflow was removed in https://github.com/mdn/workflows/pull/153.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

<!-- 🔨 If this fully resolves a GitHub issue, use "Fixes #123" -->
<!-- 👉 Highlight related pull requests using "Relates to #123" -->
<!-- ❗ If another pull request should be merged first, use "**Depends on:** #123" -->
