### PR TITLE
chore(deps): bump node from v20 to v22

### DIFF
--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -9,7 +9,7 @@ on:
         type: string
       node-version:
         description: The node version to setup and use.
-        default: 20
+        default: 22
         required: false
         type: number
       cache:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,7 +15,7 @@ name: publish-release
         type: string
       node-version:
         description: The Nodejs version to use
-        default: 20
+        default: 22
         required: false
         type: number
       npm-publish:

--- a/docs/markdown-lint.md
+++ b/docs/markdown-lint.md
@@ -27,7 +27,7 @@ Specify the target repository this action should run on. This is used to prevent
 
 The node version to setup and use.
 
-- This `input` is optional, with a default of `20`.
+- This `input` is optional, with a default of `22`.
 
 #### cache
 
@@ -77,6 +77,6 @@ jobs:
     uses: mdn/workflows/.github/workflows/markdown-lint.yml@main
     with:
       cache: "npm"
-      node-version: 20
+      node-version: 22
       target-repo: "mdn/workflows"
 ```

--- a/docs/publish-release.md
+++ b/docs/publish-release.md
@@ -36,7 +36,7 @@ This is can be one of the release types as [detailed in the release please docs]
 
 The version of Node.js to use for the release. This action supports all [active and maintenance releases](https://nodejs.org/en/about/releases/) of Node.js.
 
-- This `input` is optional with a default of `20`
+- This `input` is optional with a default of `22`
 
 #### npm-publish
 


### PR DESCRIPTION
### Description

Bumps Node.js from v20 to v22.

### Motivation

Node.js v22 is the currently active LTS version.

### Additional details

<!-- 🔗 Link to release notes, browser docs, bug trackers, source control, or other resources. -->

### Related issues and pull requests

Part of https://github.com/mdn/mdn/issues/699.