### PR TITLE
ci(workflows): assign explicit permissions

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -27,6 +27,9 @@ on:
         description: "Personal access token passed from the caller workflow"
         required: true
 
+# No GITHUB_TOKEN permissions, as we use GH_TOKEN instead.
+permissions: {}
+
 jobs:
   auto-merge:
     if: github.repository == inputs.target-repo && github.event.pull_request.user.login == 'dependabot[bot]'

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -18,6 +18,9 @@ on:
         required: false
         type: string
 
+# No GITHUB_TOKEN permissions, as we don't use it.
+permissions: {}
+
 jobs:
   markdown-lint:
     if: github.repository == inputs.target-repo

--- a/.github/workflows/new-issues.yml
+++ b/.github/workflows/new-issues.yml
@@ -13,6 +13,10 @@ on:
         required: false
         type: string
 
+permissions:
+  # Label issues.
+  issues: write
+
 jobs:
   label-new-issues:
     if: github.repository == inputs.target-repo

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -22,6 +22,9 @@ on:
         description: "Personal access token passed from the caller workflow"
         required: true
 
+# No GITHUB_TOKEN permissions, as we don't use it.
+permissions: {}
+
 jobs:
   label-rebase-needed:
     if: github.repository == inputs.target-repo

--- a/.github/workflows/pr-rebase-needed.yml
+++ b/.github/workflows/pr-rebase-needed.yml
@@ -22,7 +22,7 @@ on:
         description: "Personal access token passed from the caller workflow"
         required: true
 
-# No GITHUB_TOKEN permissions, as we don't use it.
+# No GITHUB_TOKEN permissions, as we use GH_TOKEN instead.
 permissions: {}
 
 jobs:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -43,7 +43,7 @@ name: publish-release
         description: Your NPM registry token
         required: false
 
-# No GITHUB_TOKEN permissions, as we don't use it.
+# No GITHUB_TOKEN permissions, as we use GH_TOKEN instead.
 permissions: {}
 
 jobs:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -42,6 +42,10 @@ name: publish-release
       NPM_AUTH_TOKEN:
         description: Your NPM registry token
         required: false
+
+# No GITHUB_TOKEN permissions, as we don't use it.
+permissions: {}
+
 jobs:
   release-please:
     if: github.repository == inputs.target-repo


### PR DESCRIPTION
### Description

Adds explicit `permissions:` configuration to workflow files that don't already have permissions defined either at the workflow level or for all jobs.

- If the workflow doesn't use `secrets.GITHUB_TOKEN` or `github.token`, sets `permissions: {}` to restrict all permissions.
- If the workflow uses the GitHub token, adds `permissions:` with required permissions.

### Motivation

Security best practice to explicitly declare `GITHUB_TOKEN` permissions instead of relying on default permissions, following the principle of least privilege by ensuring workflows only have the permissions they actually need.

### Additional details

See: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/924.
