### PR TITLE
ci(CODEOWNERS): add Engineering for workflows and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,11 @@
-# This file is used to add reviewers to PRs.
+# ----------------------------------------------------------------------------
+# CODEOWNERS
+# ----------------------------------------------------------------------------
+# Order is important. The last matching pattern takes precedence.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+# ----------------------------------------------------------------------------
 
-# Default
-* @mdn/core-yari-content @mdn/core-dev
+* @mdn/engineering @mdn/content-team
+
+/.github/workflows/ @mdn/engineering
+/.github/CODEOWNERS @mdn/engineering @mdn/content-team


### PR DESCRIPTION
### Description

Updates the CODEOWNERS file to ensure:
- `/.github/workflows/` is owned by `@mdn/engineering`
- `/.github/CODEOWNERS` is owned by the default code owner and `@mdn/engineering`

### Motivation

Ensures the engineering team has oversight of workflow changes, and CODEOWNERS file modifications across repositories.

### Additional details

See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

### Related issues and pull requests

Part of https://github.com/mdn/fred/issues/888.