### PR TITLE
chore(auto-merge): remove `target-repo` input

### DIFF
--- a/.github/workflows/auto-merge-workflows.yml
+++ b/.github/workflows/auto-merge-workflows.yml
@@ -2,29 +2,15 @@ name: auto-merge
 
 on:
   pull_request_target:
-    branches:
-      - main
 
-# No GITHUB_TOKEN permissions, because we use AUTOMERGE_TOKEN instead.
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   auto-merge:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login == 'dependabot[bot]'
-
-    steps:
-      - name: Dependabot metadata
-        id: dependabot-metadata
-        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
-        with:
-          github-token: ${{ secrets.AUTOMERGE_TOKEN }}
-
-      - name: Squash and merge
-
-        if: ${{ steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor' && !startsWith(steps.dependabot-metadata.outputs.previous-version, '0.') || steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' && !startsWith(steps.dependabot-metadata.outputs.previous-version, '0.0.') }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
-        run: |
-          gh pr review ${{ github.event.pull_request.html_url }} --approve 
-          gh pr comment ${{ github.event.pull_request.html_url }} --body "@dependabot squash and merge"
+    uses: mdn/workflows/.github/workflows/auto-merge.yml@main
+    if: github.repository_owner == 'mdn'
+    with:
+      auto-merge: true
+    secrets:
+      GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,10 +13,6 @@ on:
         default: false
         required: false
         type: boolean
-      target-repo:
-        description: The repo to run this action on. This is to prevent actions from running on forks unless intended.
-        required: true
-        type: string
     secrets:
       GH_TOKEN:
         description: "Personal access token passed from the caller workflow"
@@ -27,7 +23,7 @@ permissions: {}
 
 jobs:
   auto-merge:
-    if: github.repository == inputs.target-repo && github.event.pull_request.user.login == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
 
     steps:

--- a/docs/auto-merge.md
+++ b/docs/auto-merge.md
@@ -11,7 +11,7 @@ To use it you will need a [Personal Access Token](https://docs.github.com/en/git
 
 > NOTE: This action only processes pull requests opened by [Dependabot](https://github.com/dependabot).
 
-In the repository that will call this action, you need to [define a secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) named `GH_TOKEN` with the value of your Personal Access Token.
+In the repository that will call this action, you need to [define a secret](https://docs.github.com/en/actions/security-guides/encrypted-secrets#creating-encrypted-secrets-for-a-repository) named `AUTOMERGE_TOKEN` with the value of your Personal Access Token.
 
 This reusable action depends on the following actions:
 
@@ -30,12 +30,6 @@ A pull request is considered _eligible_ for auto-approve/merge if it is **not** 
 ## Inputs
 
 ### Required inputs
-
-#### target-repo
-
-Specify the target repository this action should run on. This is used to prevent actions from running on repositories other than the target repository. For example, specifying a `target-repo` of `mdn/workflows` will prevent the workflow from running on forks of `mdn/workflows`.
-
-- This `input` is required
 
 ### Optional inputs
 
@@ -60,30 +54,39 @@ In the repository that will call this action, you will need to add a `.github/wo
 ### With defaults (auto-approve only)
 
 ```yml
-name: "auto-merge"
-on: [pull_request_target]
+name: auto-merge
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
 
 jobs:
   auto-merge:
+    if: github.repository_owner == 'mdn'
     uses: mdn/workflows/.github/workflows/auto-merge.yml@main
-    with:
-      target-repo: "mdn/workflows"
     secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
 ```
 
 ### With auto-merge enabled
 
 ```yml
-name: "auto-merge"
-on: [pull_request_target]
+name: auto-merge
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
 
 jobs:
   auto-merge:
+    if: github.repository_owner == 'mdn'
     uses: mdn/workflows/.github/workflows/auto-merge.yml@main
     with:
       auto-merge: true
-      target-repo: "mdn/workflows"
     secrets:
-      GH_TOKEN: ${{ secrets.GH_TOKEN }}
+      GH_TOKEN: ${{ secrets.AUTOMERGE_TOKEN }}
 ```


### PR DESCRIPTION
### Description

Update the `auto-merge` workflow, removing the obsolete `target-repo` input.

### Motivation

Callers are meanwhile passing `{{ github.repository }}` as value, and instead prevent execution in forks via `if: github.repository_owner == 'mdn'`, so this is no longer needed.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Related to https://github.com/mdn/fred/issues/1395.