### PR TITLE
ci(auto-merge): restore `target-repo` input with deprecation note

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -13,6 +13,10 @@ on:
         default: false
         required: false
         type: boolean
+      target-repo:
+        description: "(Deprecated) No longer used. Will be removed soon!"
+        required: false
+        type: string
     secrets:
       GH_TOKEN:
         description: "Personal access token passed from the caller workflow"
@@ -27,6 +31,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Warn on deprecated inputs
+        if: inputs.target-repo != ''
+        run: echo "::warning::The 'target-repo' input is deprecated and will be removed soon. Remove it now, or your workflow will stop working then."
+
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -14,7 +14,8 @@ on:
         required: false
         type: boolean
       target-repo:
-        description: "(Deprecated) No longer used. Will be removed soon!"
+        description: |
+          (Deprecated) This input is deprecated and will be removed soon. Remove it from your workflow, or it will start failing silently. To prevent fork execution, add this to your job instead: if: github.repository_owner == 'your-org'"
         required: false
         type: string
     secrets:
@@ -33,7 +34,8 @@ jobs:
     steps:
       - name: Warn on deprecated inputs
         if: inputs.target-repo != ''
-        run: echo "::warning::The 'target-repo' input is deprecated and will be removed soon. Remove it now, or your workflow will stop working then."
+        run: |
+          echo "::warning::The 'target-repo' input is deprecated and will be removed soon. Remove it from your workflow, or it will start failing silently. To prevent fork execution, add this to your job instead: if: github.repository_owner == 'your-org'"
 
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Restore the `target-repo` input with deprecation notice.

### Motivation

Ensure workflow calls that still set this input continue to run.

### Additional details

Currently, these fail silently, see:

- https://github.com/mdn/bcd-utils/pull/291 -> checks are passing
- https://github.com/mdn/bcd-utils/actions/runs/23416571100?pr=291 -> auto-merge failed

> The workflow is not valid. .github/workflows/auto-merge.yml (Line: 14, Col: 20): Invalid input, target-repo is not defined in the referenced workflow.

### Related issues and pull requests

Follow-up of https://github.com/mdn/workflows/pull/190.