### PR TITLE
ci(auto-merge): checkout with GITHUB_TOKEN

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -23,8 +23,8 @@ on:
         description: "Personal access token passed from the caller workflow"
         required: true
 
-# No GITHUB_TOKEN permissions, as we use GH_TOKEN instead.
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   auto-merge:
@@ -41,7 +41,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ github.token }}
 
       - name: Dependabot metadata
         id: dependabot-metadata


### PR DESCRIPTION
### Description

Updates the `auto-merge` workflow to checkout using the `GITHUB_TOKEN` (instead of `GH_TOKEN`).

Also: Adds `contents: read` to the permissions.

### Motivation

Attempt to resolve errors like [this one](https://github.com/mdn/browser-compat-data/actions/runs/23643224106/job/68868857425?pr=29355):

>  Error: Input required and not supplied: token

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Follow-up of https://github.com/mdn/workflows/pull/189.
