### PR TITLE
feat(workflows): add needs-triage workflow

### DIFF
--- a/.github/workflows/needs-triage-workflows.yml
+++ b/.github/workflows/needs-triage-workflows.yml
@@ -1,0 +1,16 @@
+name: needs-triage
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+
+permissions:
+  issues: write
+
+jobs:
+  needs-triage:
+    uses: mdn/workflows/.github/workflows/needs-triage.yml@main
+    if: github.repository_owner == 'mdn'

--- a/.github/workflows/needs-triage.yml
+++ b/.github/workflows/needs-triage.yml
@@ -1,0 +1,24 @@
+name: needs-triage
+
+on:
+  workflow_call:
+    inputs:
+      label:
+        description: The label to add to the issue.
+        default: "needs triage"
+        required: false
+        type: string
+
+permissions:
+  issues: write
+
+jobs:
+  needs-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          ISSUE_URL: ${{ github.event.issue.html_url }}
+          LABEL: ${{ inputs.label }}
+        run: gh issue edit "$ISSUE_URL" --add-label "$LABEL"

--- a/README.md
+++ b/README.md
@@ -6,5 +6,6 @@ Reusable GitHub Actions workflows for use in MDN repositories.
 
 - [auto-merge](.github/workflows/auto-merge.yml) ([docs](docs/auto-merge.md)) - automatically merge pull requests
 - [lock-closed](.github/workflows/lock-closed.yml) ([docs](docs/lock-closed.md)) - lock closed issues and pull requests
+- [needs-triage](.github/workflows/needs-triage.yml) ([docs](docs/needs-triage.md)) - label issues that need triage when opened, reopened, or transferred
 - [new-issues](.github/workflows/new-issues.yml) ([docs](docs/new-issues.md)) - label new issues
 - [pr-rebase-needed](.github/workflows/pr-rebase-needed.yml) ([docs](docs/pr-rebase-needed.md)) - label pull requests that have merge conflicts

--- a/docs/needs-triage.md
+++ b/docs/needs-triage.md
@@ -1,0 +1,64 @@
+# needs-triage
+
+The `needs-triage` reusable action is located at [`.github/workflows/needs-triage.yml`](https://github.com/mdn/workflows/tree/main/.github/workflows/needs-triage.yml).
+
+It adds a label (default: `needs triage`) to an issue when it is opened, reopened, or transferred.
+
+## Inputs
+
+### Optional inputs
+
+#### label
+
+The label to add to the issue.
+
+- This `input` is optional with a default of `needs triage`.
+
+## Usage
+
+In the repository that will call this action, add a `.github/workflows/needs-triage.yml` file with the following content:
+
+### With defaults
+
+```yml
+name: needs-triage
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+
+jobs:
+  needs-triage:
+    uses: mdn/workflows/.github/workflows/needs-triage.yml@main
+```
+
+To prevent execution on forks, add an `if` condition to the job:
+
+```yml
+jobs:
+  needs-triage:
+    if: github.repository_owner == 'mdn'
+    uses: mdn/workflows/.github/workflows/needs-triage.yml@main
+```
+
+### Overriding the label
+
+```yml
+name: needs-triage
+
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+      - transferred
+
+jobs:
+  needs-triage:
+    uses: mdn/workflows/.github/workflows/needs-triage.yml@main
+    with:
+      label: "triage"
+```


### PR DESCRIPTION
<!-- 🙌 Thanks for contributing! Adding details below will help us to merge your PR faster. -->

### Description

Adds new reusable `needs-triage` workflow, used to automatically add the "needs triage" label.

### Motivation

Avoid duplicating the label add logic in every repository, and allow fine-tuning label adding, e.g. excluding certain issues.

### Additional details

<!-- 🔗 Link to documentation, bug trackers, source control, or other places providing more context -->

### Related issues and pull requests

Relates to https://github.com/mdn/fred/issues/1564.